### PR TITLE
Add support for Teensy 2.0 & 3.0

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -17,9 +17,11 @@
 
 static Adafruit_VS1053_FilePlayer *myself;
 
+#if defined(__AVR__)
 SIGNAL(TIMER0_COMPA_vect) {
   myself->feedBuffer();
 }
+#endif
 
 static void feeder(void) {
   myself->feedBuffer();
@@ -27,7 +29,7 @@ static void feeder(void) {
 
 
 
-static uint8_t dreqinttable[] = {
+static const uint8_t dreqinttable[] = {
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || defined (__AVR_ATmega328__) || defined(__AVR_ATmega8__) 
   2, 0,
   3, 1,
@@ -38,6 +40,28 @@ static uint8_t dreqinttable[] = {
   20, 3,
   19, 4,
   18, 5,
+#elif  defined(__AVR_ATmega32u4__) && defined(CORE_TEENSY)
+  5, 0,
+  6, 1,
+  7, 2,
+  8, 3,
+#elif  defined(__AVR_AT90USB1286__) && defined(CORE_TEENSY)
+  0, 0,
+  1, 1,
+  2, 2,
+  3, 3,
+  36, 4,
+  37, 5,
+  18, 6,
+  19, 7,
+#elif  defined(__arm__) && defined(CORE_TEENSY)
+  0, 0, 1, 1, 2, 2, 3, 3, 4, 4,
+  5, 5, 6, 6, 7, 7, 8, 8, 9, 9,
+  10, 10, 11, 11, 12, 12, 13, 13, 14, 14,
+  15, 15, 16, 16, 17, 17, 18, 18, 19, 19,
+  20, 20, 21, 21, 22, 22, 23, 23, 24, 24,
+  25, 25, 26, 26, 27, 27, 28, 28, 29, 29,
+  30, 30, 31, 31, 32, 32, 33, 33,
 #elif  defined(__AVR_ATmega32u4__) 
   3, 0,
   2, 1,
@@ -51,9 +75,16 @@ boolean Adafruit_VS1053_FilePlayer::useInterrupt(uint8_t type) {
   myself = this;  // oy vey
     
   if (type == VS1053_FILEPLAYER_TIMER0_INT) {
+#if defined(__AVR__)
     OCR0A = 0xAF;
     TIMSK0 |= _BV(OCIE0A);
     return true;
+#elif defined(__arm__) && defined(CORE_TEENSY)
+    IntervalTimer *t = new IntervalTimer();
+    return (t && t->begin(feeder, 1024)) ? true : false;
+#else
+    return false;
+#endif
   }
   if (type == VS1053_FILEPLAYER_PIN_INT) {
     for (uint8_t i=0; i<sizeof(dreqinttable); i+=2) {

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -25,7 +25,7 @@
 #include <SPI.h> 
 #include <SD.h>
 
-#define VS1053_FILEPLAYER_TIMER0_INT 0
+#define VS1053_FILEPLAYER_TIMER0_INT 255 // allows useInterrupt to accept pins 0 to 254
 #define VS1053_FILEPLAYER_PIN_INT 5
 
 #define VS1053_SCI_READ 0x03


### PR DESCRIPTION
Small edits to add support for Teensy 2.0 (interrupt pin assignments) and Teensy 3.0 (uses IntervalTimer instead of AVR timer0).

Confirmed working by an Adafruit customer:

http://forum.pjrc.com/threads/23970-Teensy-3-0-Ada-FRuit-VS1053-Audio-Breakout-Board-Problems?p=34375&viewfull=1#post34375
