### PR TITLE
Fix playing short files

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -193,7 +193,7 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(char *trackname) {
   
 
   // fill it up!
-  while (readyForData()) 
+  while (playingMusic && readyForData())
     feedBuffer();
 
 //  Serial.println("Ready");


### PR DESCRIPTION
This commit fixes an issue where, for very short files, the player hangs
in startPlayingFile(). The call to feedBuffer() in the initial fill-up
loop sets playingMusic to false because the full file is consumed, but
the loop never checks for this and keeps calling feedBuffer() forever.
