### PR TITLE
Reset ellasped time when start playing a new song...

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -186,18 +186,23 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(char *trackname) {
     return false;
   }
 
+  // As explained in datasheet, set twice 0 in REG_DECODETIME to set time back to 0
+  sciWrite(VS1053_REG_DECODETIME, 0x00);
+  sciWrite(VS1053_REG_DECODETIME, 0x00);
+
+
   playingMusic = true;
 
   // wait till its ready for data
   while (! readyForData() );
-  
+
 
   // fill it up!
   while (playingMusic && readyForData())
     feedBuffer();
 
 //  Serial.println("Ready");
-  
+
   return true;
 }
 


### PR DESCRIPTION
When playing multiple files, ellasped time wasn’t reset to 0.
In order to fix that, and according to datasheet (chapter 9.6.5 "SCI_DECODE_TIME (RW)"), it seems that we need to write twice a 0 in REG_DECODETIME.

Tested on an Arduino Micro + VS1053 micro shield (https://github.com/paulgreg/arduino_mp3_player).
