### PR TITLE
Set shield defaults to same as interrupt example.

### DIFF
--- a/examples/player_simple/player_simple.ino
+++ b/examples/player_simple/player_simple.ino
@@ -29,6 +29,7 @@
 #define BREAKOUT_CS     10     // VS1053 chip select pin (output)
 #define BREAKOUT_DCS    8      // VS1053 Data/command select pin (output)
 // These are the pins used for the music maker shield
+#define SHIELD_RESET  -1      // VS1053 reset pin (unused!)
 #define SHIELD_CS     7      // VS1053 chip select pin (output)
 #define SHIELD_DCS    6      // VS1053 Data/command select pin (output)
 
@@ -41,7 +42,7 @@ Adafruit_VS1053_FilePlayer musicPlayer =
   // create breakout-example object!
   Adafruit_VS1053_FilePlayer(BREAKOUT_RESET, BREAKOUT_CS, BREAKOUT_DCS, DREQ, CARDCS);
   // create shield-example object!
-  //Adafruit_VS1053_FilePlayer(SHIELD_CS, SHIELD_DCS, DREQ, CARDCS);
+  //Adafruit_VS1053_FilePlayer(SHIELD_RESET, SHIELD_CS, SHIELD_DCS, DREQ, CARDCS);
   
 void setup() {
   Serial.begin(9600);


### PR DESCRIPTION
The player_simple.ino example doesn't run properly if the shield example is uncommented due to bad arguments.  This changes the shield setup to match the one from player_interrupts.ino