### PR TITLE
Disable interrupts at the beginning of feedBuffer()...

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -215,10 +215,16 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
 }
 
 void Adafruit_VS1053_FilePlayer::feedBuffer(void) {
+  noInterrupts();
+
   // dont run twice in case interrupts collided
-  if (feedBufferSem) return;
+  if (feedBufferSem) {
+    interrupts();
+    return;
+  }
 
   feedBufferSem = true;
+  interrupts();
 
   if ((! playingMusic) // paused or stopped
       || (! currentTrack) 


### PR DESCRIPTION
…where flag is checked if feedBuffer is already running, similar to a feature of Paul Stoffregen’s fork, possibly related to issue #4

Scope: modify feedBuffer() by adding a step to disable interrupts noInterrupts() while the flag is being checked (and set) to determine if feedBuffer() is already running.

This is inspired by a change also in Paul Stoffregen's fork of this library. I had issues with a project (with a number of interrupts) occasionally crashing while playing audio. So far, after this change, I haven't observed another crash.

I did not verify this section of code is directly responsible for creating/fixing the crash. But it seems prudent and in my testing, causes no harm!

No known limitations related to platform support.