### PR TITLE
Prevent startPlayingFile from triggering the ESP8266 watchdog reset

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -201,7 +201,11 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
   playingMusic = true;
 
   // wait till its ready for data
-  while (! readyForData() );
+  while (! readyForData() ) {
+#if defined(ESP8266)
+	yield();
+#endif
+  }
 
   // fill it up!
   while (playingMusic && readyForData()) {


### PR DESCRIPTION
- Arduino board:  NodeMCU V3 (ESP8266)
- Arduino IDE version (found in Arduino -> About Arduino menu): 1.8.1

I'm using this library on my ESP8266 to play MP3 files from SD card via the breakout board. It works fine, except for the part where I start playing the file:
When calling musicPlayer.startPlayingFile(filename); for a bigger file (~3MB - it worked with a few kb sized file) it blocks for too long and triggers the ESPs watchdog. Adding a yield() seems to solve the problem.