### PR TITLE
Fixed "_cardCS not set #26"

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -99,8 +99,8 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(
   playingMusic = false;
 
   // Set the card to be disabled while we get the VS1053 up
-  pinMode(_cardCS, OUTPUT);
-  digitalWrite(_cardCS, HIGH);  
+  pinMode(cardcs, OUTPUT);
+  digitalWrite(cardcs, HIGH);  
 }
 
 Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(
@@ -111,8 +111,8 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(
   playingMusic = false;
 
   // Set the card to be disabled while we get the VS1053 up
-  pinMode(_cardCS, OUTPUT);
-  digitalWrite(_cardCS, HIGH);  
+  pinMode(cardcs, OUTPUT);
+  digitalWrite(cardcs, HIGH);  
 }
 
 
@@ -125,8 +125,8 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(
   playingMusic = false;
 
   // Set the card to be disabled while we get the VS1053 up
-  pinMode(_cardCS, OUTPUT);
-  digitalWrite(_cardCS, HIGH);  
+  pinMode(cardcs, OUTPUT);
+  digitalWrite(cardcs, HIGH);  
 }
 
 boolean Adafruit_VS1053_FilePlayer::begin(void) {

--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -97,10 +97,6 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(
                : Adafruit_VS1053(rst, cs, dcs, dreq) {
 
   playingMusic = false;
-
-  // Set the card to be disabled while we get the VS1053 up
-  pinMode(cardcs, OUTPUT);
-  digitalWrite(cardcs, HIGH);  
 }
 
 Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(
@@ -109,10 +105,6 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(
   : Adafruit_VS1053(-1, cs, dcs, dreq) {
 
   playingMusic = false;
-
-  // Set the card to be disabled while we get the VS1053 up
-  pinMode(cardcs, OUTPUT);
-  digitalWrite(cardcs, HIGH);  
 }
 
 
@@ -123,10 +115,6 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(
                : Adafruit_VS1053(mosi, miso, clk, rst, cs, dcs, dreq) {
 
   playingMusic = false;
-
-  // Set the card to be disabled while we get the VS1053 up
-  pinMode(cardcs, OUTPUT);
-  digitalWrite(cardcs, HIGH);  
 }
 
 boolean Adafruit_VS1053_FilePlayer::begin(void) {

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -178,9 +178,6 @@ class Adafruit_VS1053_FilePlayer : public Adafruit_VS1053 {
   boolean paused(void);
   boolean stopped(void);
   void pausePlaying(boolean pause);
-
- private:
-  uint8_t _cardCS;
 };
 
 #endif // ADAFRUIT_VS1053_H


### PR DESCRIPTION
Fixed the issue reported here https://github.com/adafruit/Adafruit_VS1053_Library/issues/26 about _cardCS not being initialized.