### PR TITLE
Make it possible to optionaly use SdFat library

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -13,7 +13,6 @@
  ****************************************************/
 
 #include <Adafruit_VS1053.h>
-#include <SD.h>
 
 #if defined(ARDUINO_STM32_FEATHER)
    #define digitalPinToInterrupt(x) x

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -27,7 +27,12 @@
 #endif
 
 #include <SPI.h> 
-#include <SD.h>
+#if defined(PREFER_SDFAT_LIBRARY)
+ #include <SdFat.h>
+ extern SdFat SD;
+#else
+ #include <SD.h>
+#endif
 
 // define here the size of a register!
 #if defined(ARDUINO_STM32_FEATHER)


### PR DESCRIPTION
SdFat library adds more features, like support for long filenames, but
mainly it seems to be subjectively about 10-20% faster then SD library
on my Feather M0. It's noticeable mainly when I'm patching the VS1053
and/or using bigger MP3 files.

Signed-off-by: Petr Štetiar <ynezz@true.cz>