### PR TITLE
Cleanup startPlayingFile

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -190,18 +190,6 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
   sciWrite(VS1053_REG_DECODETIME, 0x00);
 
   playingMusic = true;
-
-  // wait till its ready for data
-  while (! readyForData() ) {
-#if defined(ESP8266)
-	yield();
-#endif
-  }
-
-  // fill it up!
-  while (playingMusic && readyForData()) {
-    feedBuffer();
-  }
   
   // ok going forward, we can use the IRQ
   interrupts();


### PR DESCRIPTION
startPlayingFile seems overly complicated right now, so I'd suggest to to clean it up a bit. While filling the buffer initially sounds nice, it doesn't seem to bring any real benefit (you have to start refilling right away anyway).
Right now it's very confusing:
* feedBuffer() is called within a loop that is happening within feedBuffer_noLock anyway
* interrupts() is called afterwards even though interrupts are already enabled by feedBuffer()

In my opinion removing the complexity outweighs the "need" to initially fill the buffer.