### PR TITLE
Fix pausePlaying when currentTrack has ended (Fix #16)

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -156,8 +156,10 @@ void Adafruit_VS1053_FilePlayer::pausePlaying(boolean pause) {
   if (pause) 
     playingMusic = false;
   else {
-    playingMusic = true;
-    feedBuffer();
+    if (currentTrack) {
+      playingMusic = true;
+      feedBuffer();
+    }
   }
 }
 
@@ -376,8 +378,6 @@ uint16_t Adafruit_VS1053::loadPlugin(char *plugname) {
   plugin.close();
   return 0xFFFF;
 }
-
-
 
 
 boolean Adafruit_VS1053::readyForData(void) {


### PR DESCRIPTION
Fixes issue #16 as suggested there to prevent playingMusic to become true when currentTrack is already finished.