### PR TITLE
Fixes for DREQ handling

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -712,7 +712,7 @@ void Adafruit_VS1053::sineTest(uint8_t n, uint16_t ms) {
 
   while (!readyForData()) {
 #if defined(ESP8266)
-	yield();
+	ESP.wdtFeed();
 #endif	
   }
 

--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -586,6 +586,12 @@ boolean Adafruit_VS1053::GPIO_digitalRead(uint8_t i) {
 uint16_t Adafruit_VS1053::sciRead(uint8_t addr) {
   uint16_t data;
 
+  while (!readyForData()) {
+#if defined(ESP8266)
+	ESP.wdtFeed();
+#endif	
+  }
+  
   #ifdef SPI_HAS_TRANSACTION
   if (useHardwareSPI) SPI.beginTransaction(VS1053_CONTROL_SPI_SETTING);
   #endif
@@ -606,6 +612,12 @@ uint16_t Adafruit_VS1053::sciRead(uint8_t addr) {
 
 
 void Adafruit_VS1053::sciWrite(uint8_t addr, uint16_t data) {
+  while (!readyForData()) {
+#if defined(ESP8266)
+	ESP.wdtFeed();
+#endif	
+  }
+  
   #ifdef SPI_HAS_TRANSACTION
   if (useHardwareSPI) SPI.beginTransaction(VS1053_CONTROL_SPI_SETTING);
   #endif
@@ -698,8 +710,11 @@ void Adafruit_VS1053::sineTest(uint8_t n, uint16_t ms) {
   mode |= 0x0020;
   sciWrite(VS1053_REG_MODE, mode);
 
-  while (!digitalRead(_dreq));
-	 //  delay(10);
+  while (!readyForData()) {
+#if defined(ESP8266)
+	yield();
+#endif	
+  }
 
   #ifdef SPI_HAS_TRANSACTION
   if (useHardwareSPI) SPI.beginTransaction(VS1053_DATA_SPI_SETTING);


### PR DESCRIPTION
The datasheet states
"The DREQ pin/signal is used to signal if VS1053b’s 2048-byte FIFO is capable of receiving data. If
DREQ is high, VS1053b can take at least 32 bytes of SDI data or one SCI command. DREQ is turned
low when the stream buffer is too full and for the duration of a SCI command." which means DREQ has to be checked before sending sci commands to the VS1053. This library failed to do so which might cause some unpredictable behavior.
For the ESP8266 the watchdog is fed (yield() was not sufficient in my tests), while waiting for DREQ.