### PR TITLE
Fixed 'ISR not in IRAM' problem on ESP8266

### DIFF
--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -176,7 +176,11 @@ class Adafruit_VS1053_FilePlayer : public Adafruit_VS1053 {
   boolean useInterrupt(uint8_t type);
   File currentTrack;
   volatile boolean playingMusic;
+#if defined(ESP8266)
+  void ICACHE_RAM_ATTR feedBuffer(void);
+#else
   void feedBuffer(void);
+#endif
   static boolean isMP3File(const char* fileName);
   unsigned long mp3_ID3Jumper(File mp3);
   boolean startPlayingFile(const char *trackname);


### PR DESCRIPTION
Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

**Scope:**
I changed the `void Adafruit_VS1053_FilePlayer::feedBuffer(void)` to be changed into `void ICACHE_RAM_ATTR Adafruit_VS1053_FilePlayer::feedBuffer(void)` and the `static void feeder(void)` to be changed to `static void ICACHE_RAM_ATTR feeder(void)` if compiling for an ESP8266. This is necessary for the library to work with esp8266/Arduino core version 2.5.1 or higher.

**Known limitations:**
I'm not certain if this is backwards compatible with the esp8266/Arduino core versions 2.5.0 and lower. I haven't tried this or looked it up because I'm not sure how relevant it is.

**Tested to work with:**
- nodemcu dev board v1.0 using esp8266 core version 2.5.2

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
