### PR TITLE
Add ICACHE_RAM_ATTR to interrupt call

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -32,7 +32,7 @@ SIGNAL(TIMER0_COMPA_vect) {
 
 volatile boolean feedBufferLock = false;
 
-static void feeder(void) {
+ICACHE_RAM_ATTR static void feeder(void) {
   myself->feedBuffer();
 }
 

--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -32,7 +32,10 @@ SIGNAL(TIMER0_COMPA_vect) {
 
 volatile boolean feedBufferLock = false;
 
-ICACHE_RAM_ATTR static void feeder(void) {
+#if defined(ESP8266)
+ICACHE_RAM_ATTR
+#endif
+static void feeder(void) {
   myself->feedBuffer();
 }
 


### PR DESCRIPTION
This prevents the error of "ISR not in IRAM!" which occurs in newer Arduino builds.