### PR TITLE
FilePlayer: Add playback position to .startPlayingFile function

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -216,7 +216,7 @@ unsigned long Adafruit_VS1053_FilePlayer::mp3_ID3Jumper(File mp3) {
 }
 
 
-boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
+boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname, uint32_t pos) {
   // reset playback
   sciWrite(VS1053_REG_MODE, VS1053_MODE_SM_LINE1 | VS1053_MODE_SM_SDINEW);
   // resync
@@ -231,7 +231,9 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
   // We know we have a valid file. Check if .mp3
   // If so, check for ID3 tag and jump it if present.
   if (isMP3File(trackname)) {
-    currentTrack.seek(mp3_ID3Jumper(currentTrack));
+    currentTrack.seek(max((uint32_t) mp3_ID3Jumper(currentTrack), pos));
+  } else {
+    currentTrack.seek(pos);
   }
 
   // don't let the IRQ get triggered by accident here
@@ -259,6 +261,13 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
   interrupts();
 
   return true;
+}
+
+uint32_t Adafruit_VS1053_FilePlayer::getFilePosition() {
+  if (currentTrack)
+    return currentTrack.position();
+  else
+    return 0;
 }
 
 void Adafruit_VS1053_FilePlayer::feedBuffer(void) {

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -179,8 +179,9 @@ class Adafruit_VS1053_FilePlayer : public Adafruit_VS1053 {
   void feedBuffer(void);
   static boolean isMP3File(const char* fileName);
   unsigned long mp3_ID3Jumper(File mp3);
-  boolean startPlayingFile(const char *trackname);
+  boolean startPlayingFile(const char *trackname, uint32_t pos = 0);
   boolean playFullFile(const char *trackname);
+  uint32_t getFilePosition();	
   void stopPlaying(void);
   boolean paused(void);
   boolean stopped(void);


### PR DESCRIPTION
The original .startPlayingFile function of the Adafruit_VS1053_FilePlayer class always starts playback from position 0. This pull request proposes very few changes to allow for an optional position input for the .startPlayingFile function in order to start playback also from a defined position which is not 0. In addition, the new getFilePosition function allows to check for the current playback position of a file.

These changes were proposed by adafruit_support_rick in this post: [https://forums.adafruit.com/viewtopic.php?f=25&t=123646](url). I only changed the seek part a bit, such that the approach also works for mp3 files.

The changes were successfully tested with the Arduino 1.8.11 IDE, an Adafruit Feather ESP8266 and the Music Maker FeatherWing w/ Amp.