### PR TITLE
Use wdtFeed() instead of yield() to avoid crash

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -255,7 +255,7 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
   // wait till its ready for data
   while (!readyForData()) {
 #if defined(ESP8266)
-    yield();
+    ESP.wdtFeed();
 #endif
   }
 


### PR DESCRIPTION
* I replaced the yield(); on ESP8266 with a ESP.wdtFeed(); since the yield kept the ESP crashing, while des wdtFeed works perfectly fine. I have no good explanation for thie behaviour but I experienced it with multiple boards and setups.