### PR TITLE
Added ESP32 interrupt based buffer feeding

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -41,10 +41,25 @@ SIGNAL(TIMER0_COMPA_vect) { myself->feedBuffer(); }
 
 volatile boolean feedBufferLock = false; //!< Locks feeding the buffer
 
+#if defined(ESP32)
+static SemaphoreHandle_t bufferSemaphore;
+
+static void feedTask(void *param) {
+  while (true) {
+    xSemaphoreTake(bufferSemaphore, portMAX_DELAY);
+    myself->feedBuffer();
+  }
+}
+
+static void IRAM_ATTR feeder(void) {
+  xSemaphoreGiveFromISR(bufferSemaphore, NULL);
+}
+#else
 #if defined(ESP8266)
 ICACHE_RAM_ATTR
 #endif
 static void feeder(void) { myself->feedBuffer(); }
+#endif
 
 #define VS1053_CONTROL_SPI_SETTING                                             \
   SPISettings(250000, MSBFIRST, SPI_MODE0) //!< VS1053 SPI control settings
@@ -86,6 +101,10 @@ boolean Adafruit_VS1053_FilePlayer::useInterrupt(uint8_t type) {
 #endif
   }
   if (type == VS1053_FILEPLAYER_PIN_INT) {
+#if defined(ESP32)
+       bufferSemaphore = xSemaphoreCreateBinary();
+       xTaskCreatePinnedToCore(feedTask, "VS1053Feeder", 1536, NULL, 10, NULL, 0); // Arduino main loop is on core 1, so process on the 'other' core
+#endif
     int8_t irq = digitalPinToInterrupt(_dreq);
     // Serial.print("Using IRQ "); Serial.println(irq);
     if (irq == -1)


### PR DESCRIPTION
An ESP32 compatible interrupt buffer feeder (based on a task running on the other ESP32 core) that was originally implemented based on v1.0.4: https://github.com/danclarke/Adafruit_VS1053_Library/

I merely ported the changes (for this PR).