### PR TITLE
Add fast forward feature to playing sound tracks.

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -317,8 +317,8 @@ uint16_t Adafruit_VS1053_FilePlayer::getPlaySpeed() {
   noInterrupts();
   sciWrite(VS1053_SCI_WRAMADDR, VS1053_PARA_PLAYSPEED);
   uint16_t speed = sciRead(VS1053_SCI_WRAM);
-  return speed;
   interrupts();
+  return speed;
 }
 
 // set playback speed: 0 or 1 for normal speed, 2 for 2x, 3 for 3x, etc.

--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -312,6 +312,23 @@ void Adafruit_VS1053_FilePlayer::feedBuffer_noLock(void) {
   }
 }
 
+// get current playback speed. 0 or 1 indicates normal speed
+uint16_t Adafruit_VS1053_FilePlayer::getPlaySpeed() {
+  noInterrupts();
+  sciWrite(VS1053_SCI_WRAMADDR, VS1053_PARA_PLAYSPEED);
+  uint16_t speed = sciRead(VS1053_SCI_WRAM);
+  return speed;
+  interrupts();
+}
+
+// set playback speed: 0 or 1 for normal speed, 2 for 2x, 3 for 3x, etc.
+void Adafruit_VS1053_FilePlayer::setPlaySpeed(uint16_t speed) {
+  noInterrupts();
+  sciWrite(VS1053_SCI_WRAMADDR, VS1053_PARA_PLAYSPEED);
+  sciWrite(VS1053_SCI_WRAM, speed);
+  interrupts();
+}
+
 /***************************************************************/
 
 /* VS1053 'low level' interface */

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -106,6 +106,8 @@ typedef volatile RwReg PortReg; //!< Type definition/alias used to specify the
   0x0E //!< SCI_AICTRL register 2. Used to access the user's application program
 #define VS1053_SCI_AICTRL3                                                     \
   0x0F //!< SCI_AICTRL register 3. Used to access the user's application program
+#define VS1053_SCI_WRAM 0x06
+#define VS1053_SCI_WRAMADDR 0x07
 
 #define VS1053_PARA_PLAYSPEED 0x1E04
 
@@ -401,6 +403,16 @@ public:
    * @param pause whether or not to pause playback
    */
   void pausePlaying(boolean pause);
+  /*!
+   * @brief Determine current playback speed
+   * @return Returns playback speed, i.e. 1 for 1x, 2 for 2x, 3 for 3x
+   */
+  uint16_t getPlaySpeed();
+  /*!
+   * @brief Set playback speed
+   * @param speed Set playback speed, i.e. 1 for 1x, 2 for 2x, 3 for 3x
+   */
+  void setPlaySpeed(uint16_t speed);
 
 private:
   void feedBuffer_noLock(void);

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -107,6 +107,8 @@ typedef volatile RwReg PortReg; //!< Type definition/alias used to specify the
 #define VS1053_SCI_AICTRL3                                                     \
   0x0F //!< SCI_AICTRL register 3. Used to access the user's application program
 
+#define VS1053_PARA_PLAYSPEED 0x1E04
+
 #define VS1053_DATABUFFERLEN 32 //!< Length of the data buffer
 
 /*!

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -109,7 +109,7 @@ typedef volatile RwReg PortReg; //!< Type definition/alias used to specify the
 #define VS1053_SCI_WRAM 0x06     //!< RAM write/read
 #define VS1053_SCI_WRAMADDR 0x07 //!< Base address for RAM write/read
 
-#define VS1053_PARA_PLAYSPEED 0x1E04 //<! 0,1 = normal speed, 2 = 2x, 3 = 3x etc
+#define VS1053_PARA_PLAYSPEED 0x1E04 //!< 0,1 = normal speed, 2 = 2x, 3 = 3x etc
 
 #define VS1053_DATABUFFERLEN 32 //!< Length of the data buffer
 

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -106,10 +106,10 @@ typedef volatile RwReg PortReg; //!< Type definition/alias used to specify the
   0x0E //!< SCI_AICTRL register 2. Used to access the user's application program
 #define VS1053_SCI_AICTRL3                                                     \
   0x0F //!< SCI_AICTRL register 3. Used to access the user's application program
-#define VS1053_SCI_WRAM 0x06
-#define VS1053_SCI_WRAMADDR 0x07
+#define VS1053_SCI_WRAM 0x06     //!< RAM write/read
+#define VS1053_SCI_WRAMADDR 0x07 //!< Base address for RAM write/read
 
-#define VS1053_PARA_PLAYSPEED 0x1E04
+#define VS1053_PARA_PLAYSPEED 0x1E04 //<! 0,1 = normal speed, 2 = 2x, 3 = 3x etc
 
 #define VS1053_DATABUFFERLEN 32 //!< Length of the data buffer
 


### PR DESCRIPTION
This pull request adds the ability to speed-up or fast forward tracks using the built-in feature of the VS1053 chip. Two functions were added:

- setPlaySpeed(uint16_t speed) - set the play speed. Speed is defined by an integer, i.e. 1 is normal playback, 2 is 2x playback, 3 is 3x playback, etc.
- getPlaySpeed() - get the current play speed

I have been using it in my own code for a while and thought it would be useful to contribute it to the library.

To test, simply add a statement like "musicPlayer.setPlaySpeed(2);" to the player_simple.ino example prior to the musicPlayer.startPlayingFile() call.
