### PR TITLE
Update to BusIO

### DIFF
--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -166,23 +166,6 @@ public:
    * @param ms Delay (in ms)
    */
   void sineTest(uint8_t n, uint16_t ms);
-  // /*!
-  //  * @brief Low-level SPI write operation
-  //  * @param d What to write
-  //  */
-  // void spiwrite(uint8_t d);
-  // /*!
-  //  * @brief Low-level SPI write operation
-  //  * @param c Pointer to a buffer containing the data to send
-  //  * @param num How many elements in the buffer should be sent
-  //  */
-  // void spiwrite(uint8_t *c, uint16_t num);
-  // /*!
-  //  * @brief Low-level SPI read operation
-  //  * @return Returns a byte read from SPI
-  //  */
-  // uint8_t spiread(void);
-
   /*!
    * @brief Reads the DECODETIME register from the chip
    * @return Returns the decode time as an unsigned 16-bit integer

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -17,7 +17,8 @@
 #include "wiring_private.h"
 #endif
 
-#include <SPI.h>
+#include <Adafruit_SPIDevice.h>
+
 #if defined(PREFER_SDFAT_LIBRARY)
 #include <SdFat.h>
 extern SdFat SD;
@@ -165,22 +166,22 @@ public:
    * @param ms Delay (in ms)
    */
   void sineTest(uint8_t n, uint16_t ms);
-  /*!
-   * @brief Low-level SPI write operation
-   * @param d What to write
-   */
-  void spiwrite(uint8_t d);
-  /*!
-   * @brief Low-level SPI write operation
-   * @param c Pointer to a buffer containing the data to send
-   * @param num How many elements in the buffer should be sent
-   */
-  void spiwrite(uint8_t *c, uint16_t num);
-  /*!
-   * @brief Low-level SPI read operation
-   * @return Returns a byte read from SPI
-   */
-  uint8_t spiread(void);
+  // /*!
+  //  * @brief Low-level SPI write operation
+  //  * @param d What to write
+  //  */
+  // void spiwrite(uint8_t d);
+  // /*!
+  //  * @brief Low-level SPI write operation
+  //  * @param c Pointer to a buffer containing the data to send
+  //  * @param num How many elements in the buffer should be sent
+  //  */
+  // void spiwrite(uint8_t *c, uint16_t num);
+  // /*!
+  //  * @brief Low-level SPI read operation
+  //  * @return Returns a byte read from SPI
+  //  */
+  // uint8_t spiread(void);
 
   /*!
    * @brief Reads the DECODETIME register from the chip
@@ -286,12 +287,16 @@ protected:
   uint32_t _dreq;
 
 private:
+  Adafruit_SPIDevice *spi_dev_ctrl = NULL; ///< Pointer to SPI dev for control
+  Adafruit_SPIDevice *spi_dev_data = NULL; ///< Pointer to SPI dev for data
   int32_t _mosi, _miso, _clk, _reset, _cs, _dcs;
   boolean useHardwareSPI;
 #else
 protected:
   uint8_t _dreq; //!< Data request pin
 private:
+  Adafruit_SPIDevice *spi_dev_ctrl = NULL; ///< Pointer to SPI dev for control
+  Adafruit_SPIDevice *spi_dev_data = NULL; ///< Pointer to SPI dev for data
   int8_t _mosi, _miso, _clk, _reset, _cs, _dcs;
   boolean useHardwareSPI;
 #endif

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This is a library for the Adafruit VS1053 Codec Breakout and Music Mak
 category=Device Control
 url=https://github.com/adafruit/Adafruit_VS1053_Library
 architectures=*
-depends=SD
+depends=SD, Adafruit BusIO


### PR DESCRIPTION
For #81. Updates SPI to use BusIO.

Hardware SPI tested and works on Feather M4 and Feather ESP32 V2 using `feather_player` example.

Software SPI is still essentially broken since this library's current usage of SD is hard coded for hardware SPI. SD management is also split between user sketch code and library code.

Also, interrupt playback appears to *still* be not working for ESP32. Even attaching the interrupt pin will cause the sketch to fail. This seems to be a combination of ESP32's WDT and the behavior of DREQ with current library code. DREQ can toggle for reasons other than "feed buffer" (ex: sci write), which causes eventual grief. For ESP32, these lines were commented out in the sketch:
```cpp
//#if defined(__AVR_ATmega32U4__) 
//  // Timer interrupts are not suggested, better to use DREQ interrupt!
//  // but we don't have them on the 32u4 feather...
//  musicPlayer.useInterrupt(VS1053_FILEPLAYER_TIMER0_INT); // timer int
//#else
//  // If DREQ is on an interrupt pin we can do background
//  // audio playing
//  musicPlayer.useInterrupt(VS1053_FILEPLAYER_PIN_INT);  // DREQ int
//#endif
```