### PR TITLE
Add a way to control the type of the SdFat file being used

### DIFF
--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -19,9 +19,14 @@
 
 #include <Adafruit_SPIDevice.h>
 
-#if defined(PREFER_SDFAT_LIBRARY)
+#if defined(PREFER_SDFAT_LIBRARY) || defined(USE_SDFAT_FAT32)
 #include <SdFat.h>
+#if defined(USE_SDFAT_FAT32)
+extern SdFat32 SD;
+typedef File32 File;
+#else
 extern SdFat SD;
+#endif
 #else
 #include <SD.h>
 #endif


### PR DESCRIPTION
This change introduce a new USE_SDFAT_FAT32 preprocessor variable that can be set to control the compilation of the library. When set, the library will use the File32 and SdFat32 types from the SdFat library rather than the default File and SdFat whose meaning is context dependant.

This serves two purposes:
- when an Arduino core has an FS.h header then the current code will not compile because the SdFat and File are not defined.
- the default SdFat File type on modern core is a typedef for SdFat FsFile type, which has a subset of the interface of the File32 one, which also prevent some existing code from compiling.

This change is a no-op for people who don’t define the new variable, so it should not break any existing code.