### PR TITLE
compatibility with Arduino UNO R4 Wifi board

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -25,7 +25,7 @@
 
 #include <Adafruit_VS1053.h>
 
-#if defined(ARDUINO_STM32_FEATHER) 
+#if defined(ARDUINO_STM32_FEATHER)
 #define digitalPinToInterrupt(x) x
 #endif
 
@@ -40,6 +40,7 @@ SIGNAL(TIMER0_COMPA_vect) { myself->feedBuffer(); }
 #endif
 
 volatile boolean feedBufferLock = false; //!< Locks feeding the buffer
+boolean _loopPlayback; //!< internal variable, used to control playback looping
 
 #if defined(ESP8266)
 ICACHE_RAM_ATTR
@@ -102,6 +103,7 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t rst, int8_t cs,
 
   playingMusic = false;
   _cardCS = cardcs;
+  _loopPlayback = false;
 }
 
 Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t cs, int8_t dcs,
@@ -111,6 +113,7 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t cs, int8_t dcs,
 
   playingMusic = false;
   _cardCS = cardcs;
+  _loopPlayback = false;
 }
 
 Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t mosi, int8_t miso,
@@ -122,6 +125,7 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t mosi, int8_t miso,
 
   playingMusic = false;
   _cardCS = cardcs;
+  _loopPlayback = false;
 }
 
 boolean Adafruit_VS1053_FilePlayer::begin(void) {
@@ -173,6 +177,12 @@ boolean Adafruit_VS1053_FilePlayer::paused(void) {
 boolean Adafruit_VS1053_FilePlayer::stopped(void) {
   return (!playingMusic && !currentTrack);
 }
+
+void Adafruit_VS1053_FilePlayer::playbackLoop(boolean loopState) {
+  _loopPlayback = loopState;
+}
+
+boolean Adafruit_VS1053_FilePlayer::playbackLooped() { return _loopPlayback; }
 
 // Just checks to see if the name ends in ".mp3"
 boolean Adafruit_VS1053_FilePlayer::isMP3File(const char *fileName) {
@@ -297,14 +307,41 @@ void Adafruit_VS1053_FilePlayer::feedBuffer_noLock(void) {
     int bytesread = currentTrack.read(mp3buffer, VS1053_DATABUFFERLEN);
 
     if (bytesread == 0) {
-      // must be at the end of the file, wrap it up!
-      playingMusic = false;
-      currentTrack.close();
-      break;
+      // must be at the end of the file
+      if (_loopPlayback) {
+        // play in loop
+        if (isMP3File(currentTrack.name())) {
+          currentTrack.seek(mp3_ID3Jumper(currentTrack));
+        } else {
+          currentTrack.seek(0);
+        }
+      } else {
+        // wrap it up!
+        playingMusic = false;
+        currentTrack.close();
+        break;
+      }
     }
 
     playData(mp3buffer, bytesread);
   }
+}
+
+// get current playback speed. 0 or 1 indicates normal speed
+uint16_t Adafruit_VS1053_FilePlayer::getPlaySpeed() {
+  noInterrupts();
+  sciWrite(VS1053_SCI_WRAMADDR, VS1053_PARA_PLAYSPEED);
+  uint16_t speed = sciRead(VS1053_SCI_WRAM);
+  interrupts();
+  return speed;
+}
+
+// set playback speed: 0 or 1 for normal speed, 2 for 2x, 3 for 3x, etc.
+void Adafruit_VS1053_FilePlayer::setPlaySpeed(uint16_t speed) {
+  noInterrupts();
+  sciWrite(VS1053_SCI_WRAMADDR, VS1053_PARA_PLAYSPEED);
+  sciWrite(VS1053_SCI_WRAM, speed);
+  interrupts();
 }
 
 /***************************************************************/

--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -25,7 +25,7 @@
 
 #include <Adafruit_VS1053.h>
 
-#if defined(ARDUINO_STM32_FEATHER)
+#if defined(ARDUINO_STM32_FEATHER) 
 #define digitalPinToInterrupt(x) x
 #endif
 
@@ -40,7 +40,6 @@ SIGNAL(TIMER0_COMPA_vect) { myself->feedBuffer(); }
 #endif
 
 volatile boolean feedBufferLock = false; //!< Locks feeding the buffer
-boolean _loopPlayback; //!< internal variable, used to control playback looping
 
 #if defined(ESP8266)
 ICACHE_RAM_ATTR
@@ -103,7 +102,6 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t rst, int8_t cs,
 
   playingMusic = false;
   _cardCS = cardcs;
-  _loopPlayback = false;
 }
 
 Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t cs, int8_t dcs,
@@ -113,7 +111,6 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t cs, int8_t dcs,
 
   playingMusic = false;
   _cardCS = cardcs;
-  _loopPlayback = false;
 }
 
 Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t mosi, int8_t miso,
@@ -125,7 +122,6 @@ Adafruit_VS1053_FilePlayer::Adafruit_VS1053_FilePlayer(int8_t mosi, int8_t miso,
 
   playingMusic = false;
   _cardCS = cardcs;
-  _loopPlayback = false;
 }
 
 boolean Adafruit_VS1053_FilePlayer::begin(void) {
@@ -177,12 +173,6 @@ boolean Adafruit_VS1053_FilePlayer::paused(void) {
 boolean Adafruit_VS1053_FilePlayer::stopped(void) {
   return (!playingMusic && !currentTrack);
 }
-
-void Adafruit_VS1053_FilePlayer::playbackLoop(boolean loopState) {
-  _loopPlayback = loopState;
-}
-
-boolean Adafruit_VS1053_FilePlayer::playbackLooped() { return _loopPlayback; }
 
 // Just checks to see if the name ends in ".mp3"
 boolean Adafruit_VS1053_FilePlayer::isMP3File(const char *fileName) {
@@ -307,41 +297,14 @@ void Adafruit_VS1053_FilePlayer::feedBuffer_noLock(void) {
     int bytesread = currentTrack.read(mp3buffer, VS1053_DATABUFFERLEN);
 
     if (bytesread == 0) {
-      // must be at the end of the file
-      if (_loopPlayback) {
-        // play in loop
-        if (isMP3File(currentTrack.name())) {
-          currentTrack.seek(mp3_ID3Jumper(currentTrack));
-        } else {
-          currentTrack.seek(0);
-        }
-      } else {
-        // wrap it up!
-        playingMusic = false;
-        currentTrack.close();
-        break;
-      }
+      // must be at the end of the file, wrap it up!
+      playingMusic = false;
+      currentTrack.close();
+      break;
     }
 
     playData(mp3buffer, bytesread);
   }
-}
-
-// get current playback speed. 0 or 1 indicates normal speed
-uint16_t Adafruit_VS1053_FilePlayer::getPlaySpeed() {
-  noInterrupts();
-  sciWrite(VS1053_SCI_WRAMADDR, VS1053_PARA_PLAYSPEED);
-  uint16_t speed = sciRead(VS1053_SCI_WRAM);
-  interrupts();
-  return speed;
-}
-
-// set playback speed: 0 or 1 for normal speed, 2 for 2x, 3 for 3x, etc.
-void Adafruit_VS1053_FilePlayer::setPlaySpeed(uint16_t speed) {
-  noInterrupts();
-  sciWrite(VS1053_SCI_WRAMADDR, VS1053_PARA_PLAYSPEED);
-  sciWrite(VS1053_SCI_WRAM, speed);
-  interrupts();
 }
 
 /***************************************************************/
@@ -362,13 +325,18 @@ Adafruit_VS1053::Adafruit_VS1053(int8_t mosi, int8_t miso, int8_t clk,
   _dreq = dreq;
 
   useHardwareSPI = false;
-
+#if defined(ARDUINO_UNOR4_WIFI)
+  pinMode(_clk, OUTPUT);
+  pinMode(_miso, INPUT);
+  pinMode(_mosi, OUTPUT);
+#else
   clkportreg = portOutputRegister(digitalPinToPort(_clk));
   clkpin = digitalPinToBitMask(_clk);
   misoportreg = portInputRegister(digitalPinToPort(_miso));
   misopin = digitalPinToBitMask(_miso);
   mosiportreg = portOutputRegister(digitalPinToPort(_mosi));
   mosipin = digitalPinToBitMask(_mosi);
+#endif
 }
 
 Adafruit_VS1053::Adafruit_VS1053(int8_t rst, int8_t cs, int8_t dcs,

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -109,6 +109,10 @@ typedef volatile RwReg PortReg; //!< Type definition/alias used to specify the
   0x0E //!< SCI_AICTRL register 2. Used to access the user's application program
 #define VS1053_SCI_AICTRL3                                                     \
   0x0F //!< SCI_AICTRL register 3. Used to access the user's application program
+#define VS1053_SCI_WRAM 0x06     //!< RAM write/read
+#define VS1053_SCI_WRAMADDR 0x07 //!< Base address for RAM write/read
+
+#define VS1053_PARA_PLAYSPEED 0x1E04 //!< 0,1 = normal speed, 2 = 2x, 3 = 3x etc
 
 #define VS1053_DATABUFFERLEN 32 //!< Length of the data buffer
 
@@ -389,6 +393,28 @@ public:
    * @param pause whether or not to pause playback
    */
   void pausePlaying(boolean pause);
+  /*!
+   * @brief Set state for playback looping
+   * @param loopState Sets playback loop state (Note: Only use with
+   * startPlayingFile, if used with playFullFile no subsequent code in the
+   * sketch executes)
+   */
+  void playbackLoop(boolean loopState);
+  /*!
+   * @brief Retrieve playback loop state
+   * @return Returns true when looped playback is enabled
+   */
+  boolean playbackLooped();
+  /*!
+   * @brief Determine current playback speed
+   * @return Returns playback speed, i.e. 1 for 1x, 2 for 2x, 3 for 3x
+   */
+  uint16_t getPlaySpeed();
+  /*!
+   * @brief Set playback speed
+   * @param speed Set playback speed, i.e. 1 for 1x, 2 for 2x, 3 for 3x
+   */
+  void setPlaySpeed(uint16_t speed);
 
 private:
   void feedBuffer_noLock(void);

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -12,9 +12,11 @@
 #include <pins_arduino.h>
 #endif
 
-#if !defined(ARDUINO_STM32_FEATHER)
+#if !defined(ARDUINO_STM32_FEATHER) && !defined(ARDUINO_UNOR4_WIFI)
+#if !defined(ARDUINO_UNOR4_MINIMA)
 #include "pins_arduino.h"
 #include "wiring_private.h"
+#endif
 #endif
 
 #include <Adafruit_SPIDevice.h>
@@ -107,10 +109,6 @@ typedef volatile RwReg PortReg; //!< Type definition/alias used to specify the
   0x0E //!< SCI_AICTRL register 2. Used to access the user's application program
 #define VS1053_SCI_AICTRL3                                                     \
   0x0F //!< SCI_AICTRL register 3. Used to access the user's application program
-#define VS1053_SCI_WRAM 0x06     //!< RAM write/read
-#define VS1053_SCI_WRAMADDR 0x07 //!< Base address for RAM write/read
-
-#define VS1053_PARA_PLAYSPEED 0x1E04 //!< 0,1 = normal speed, 2 = 2x, 3 = 3x etc
 
 #define VS1053_DATABUFFERLEN 32 //!< Length of the data buffer
 
@@ -391,28 +389,6 @@ public:
    * @param pause whether or not to pause playback
    */
   void pausePlaying(boolean pause);
-  /*!
-   * @brief Set state for playback looping
-   * @param loopState Sets playback loop state (Note: Only use with
-   * startPlayingFile, if used with playFullFile no subsequent code in the
-   * sketch executes)
-   */
-  void playbackLoop(boolean loopState);
-  /*!
-   * @brief Retrieve playback loop state
-   * @return Returns true when looped playback is enabled
-   */
-  boolean playbackLooped();
-  /*!
-   * @brief Determine current playback speed
-   * @return Returns playback speed, i.e. 1 for 1x, 2 for 2x, 3 for 3x
-   */
-  uint16_t getPlaySpeed();
-  /*!
-   * @brief Set playback speed
-   * @param speed Set playback speed, i.e. 1 for 1x, 2 for 2x, 3 for 3x
-   */
-  void setPlaySpeed(uint16_t speed);
 
 private:
   void feedBuffer_noLock(void);


### PR DESCRIPTION
faced compilation errors when compiling the library with Arduino R4 Uno Wifi:

1. Adafruit_VS1053.h
 ```
fatal error: wiring_private.h: No such file or directory
 #include "wiring_private.h"
```
I have seen that it was fixed in another library, I did the same fix in this

2.Adafruit_VS1053.cpp
```
Arduino.h:75:92: error: cannot convert 'volatile uint16_t* {aka volatile short unsigned int*}' to 'PortReg* {aka volatile long unsigned int*}' in assignment
 #define portOutputRegister(port)    &(((R_PORT0_Type *)IOPORT_PRV_PORT_ADDRESS(port))->PODR)

Adafruit_VS1053.cpp:332:16: note: in expansion of macro 'portOutputRegister'
   clkportreg = portOutputRegister(digitalPinToPort(_clk));
```
used pinMode Function instead of portOutputRegister & portInputRegister