### PR TITLE
Added support for File.read to return -1 preventing infinite loop

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -306,7 +306,7 @@ void Adafruit_VS1053_FilePlayer::feedBuffer_noLock(void) {
     // Read some audio data from the SD card file
     int bytesread = currentTrack.read(mp3buffer, VS1053_DATABUFFERLEN);
 
-    if (bytesread == 0) {
+    if (bytesread <= 0) {
       // must be at the end of the file
       if (_loopPlayback) {
         // play in loop


### PR DESCRIPTION
`File.read()` has the potential to return -1. I experience this with cheaper SD Cards. 

In the case of returning -1, `File.read()` will continue to return the same bytes but never advance the position in the file. 

This causes an infinite loop inside of `Adafruit_VS1053_FilePlayer::feedBuffer_noLock` where the VS1053 is always ready for data because it's not receiving any.