### PR TITLE
Disable interrupts conditionally

### DIFF
--- a/Adafruit_VS1053.cpp
+++ b/Adafruit_VS1053.cpp
@@ -246,7 +246,6 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
     return false;
   }
 
-
   // We know we have a valid file. Check if .mp3
   // If so, check for ID3 tag and jump it if present.
   if (isMP3File(trackname)) {
@@ -254,7 +253,8 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
   }
 
   // don't let the IRQ get triggered by accident here
-  if (usingInterrupts) noInterrupts();
+  if (usingInterrupts)
+    noInterrupts();
 
   // As explained in datasheet, set twice 0 in REG_DECODETIME to set time back
   // to 0
@@ -283,7 +283,8 @@ boolean Adafruit_VS1053_FilePlayer::startPlayingFile(const char *trackname) {
 }
 
 void Adafruit_VS1053_FilePlayer::feedBuffer(void) {
-  if (usingInterrupts) noInterrupts();
+  if (usingInterrupts)
+    noInterrupts();
   // dont run twice in case interrupts collided
   // This isn't a perfect lock as it may lose one feedBuffer request if
   // an interrupt occurs before feedBufferLock is reset to false. This
@@ -335,7 +336,8 @@ void Adafruit_VS1053_FilePlayer::feedBuffer_noLock(void) {
 
 // get current playback speed. 0 or 1 indicates normal speed
 uint16_t Adafruit_VS1053_FilePlayer::getPlaySpeed() {
-  if (usingInterrupts) noInterrupts();
+  if (usingInterrupts)
+    noInterrupts();
   sciWrite(VS1053_SCI_WRAMADDR, VS1053_PARA_PLAYSPEED);
   uint16_t speed = sciRead(VS1053_SCI_WRAM);
   interrupts();
@@ -344,7 +346,8 @@ uint16_t Adafruit_VS1053_FilePlayer::getPlaySpeed() {
 
 // set playback speed: 0 or 1 for normal speed, 2 for 2x, 3 for 3x, etc.
 void Adafruit_VS1053_FilePlayer::setPlaySpeed(uint16_t speed) {
-  if (usingInterrupts) noInterrupts();
+  if (usingInterrupts)
+    noInterrupts();
   sciWrite(VS1053_SCI_WRAMADDR, VS1053_PARA_PLAYSPEED);
   sciWrite(VS1053_SCI_WRAM, speed);
   interrupts();
@@ -480,7 +483,8 @@ void Adafruit_VS1053::setVolume(uint8_t left, uint8_t right) {
   v <<= 8;
   v |= right;
 
-  if (usingInterrupts) noInterrupts(); // cli();
+  if (usingInterrupts)
+    noInterrupts(); // cli();
 
   sciWrite(VS1053_REG_VOLUME, v);
 
@@ -488,7 +492,8 @@ void Adafruit_VS1053::setVolume(uint8_t left, uint8_t right) {
 }
 
 uint16_t Adafruit_VS1053::decodeTime() {
-  if (usingInterrupts) noInterrupts();
+  if (usingInterrupts)
+    noInterrupts();
   uint16_t t = sciRead(VS1053_REG_DECODETIME);
   interrupts(); // sei();
   return t;

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -281,6 +281,7 @@ private:
 #else
 protected:
   uint8_t _dreq; //!< Data request pin
+  boolean usingInterrupts = false;
 private:
   Adafruit_SPIDevice *spi_dev_ctrl = NULL; ///< Pointer to SPI dev for control
   Adafruit_SPIDevice *spi_dev_data = NULL; ///< Pointer to SPI dev for data

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -271,7 +271,7 @@ public:
 
 #ifdef ARDUINO_ARCH_SAMD
 protected:
-  uint32_t _dreq; //!< Data request pin
+  uint32_t _dreq;                  //!< Data request pin
   boolean usingInterrupts = false; //!< True if using interrupts
 
 private:
@@ -281,7 +281,7 @@ private:
   boolean useHardwareSPI;
 #else
 protected:
-  uint8_t _dreq; //!< Data request pin
+  uint8_t _dreq;                   //!< Data request pin
   boolean usingInterrupts = false; //!< True if using interrupts
 
 private:

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -271,8 +271,8 @@ public:
 
 #ifdef ARDUINO_ARCH_SAMD
 protected:
-  uint32_t _dreq;
-  boolean usingInterrupts = false;
+  uint32_t _dreq; //!< Data request pin
+  boolean usingInterrupts = false; //!< True if using interrupts
 
 private:
   Adafruit_SPIDevice *spi_dev_ctrl = NULL; ///< Pointer to SPI dev for control
@@ -282,7 +282,7 @@ private:
 #else
 protected:
   uint8_t _dreq; //!< Data request pin
-  boolean usingInterrupts = false;
+  boolean usingInterrupts = false; //!< True if using interrupts
 
 private:
   Adafruit_SPIDevice *spi_dev_ctrl = NULL; ///< Pointer to SPI dev for control

--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -272,6 +272,7 @@ public:
 #ifdef ARDUINO_ARCH_SAMD
 protected:
   uint32_t _dreq;
+  boolean usingInterrupts = false;
 
 private:
   Adafruit_SPIDevice *spi_dev_ctrl = NULL; ///< Pointer to SPI dev for control
@@ -282,6 +283,7 @@ private:
 protected:
   uint8_t _dreq; //!< Data request pin
   boolean usingInterrupts = false;
+
 private:
   Adafruit_SPIDevice *spi_dev_ctrl = NULL; ///< Pointer to SPI dev for control
   Adafruit_SPIDevice *spi_dev_data = NULL; ///< Pointer to SPI dev for data


### PR DESCRIPTION
This is a nominal fix for the issue raised in this forum post:
https://forums.adafruit.com/viewtopic.php?t=217653

It does *not* fix interrupt playback. It simply protects from unnecessarily disabling interrupts if not using interrupt based playback, which prevented even non-interrupt playback from working.

Tested with an Arduino Giga R1 using the `player_simple` example from this library - modified for shield pins and commenting out call to  `musicPlayer.useInterrupt()`. The call to `playFullFile()` now works, but not `startPlayingFile()` , etc.

