### PR TITLE
Patch for Uno R4

### DIFF
--- a/Adafruit_VS1053.h
+++ b/Adafruit_VS1053.h
@@ -12,7 +12,8 @@
 #include <pins_arduino.h>
 #endif
 
-#if !defined(ARDUINO_STM32_FEATHER)
+#if !defined(ARDUINO_STM32_FEATHER) && !defined(ARDUINO_UNOR4_WIFI) &&         \
+    !defined(ARDUINO_UNOR4_MINIMA)
 #include "pins_arduino.h"
 #include "wiring_private.h"
 #endif


### PR DESCRIPTION
Simple patch to preproc logic for Uno R4. This is an alternate to #95 which now has merge conflicts and includes additional fixes taken care of with #102.

Tested with `player_simple` library example sketch on an Uno R4 WiFi.
