### PR TITLE
example/feather_player support for ESP32 S2/S3 Feathers

### DIFF
--- a/examples/feather_player/feather_player.ino
+++ b/examples/feather_player/feather_player.ino
@@ -22,6 +22,19 @@
   #define CARDCS          5     // Card chip select pin
   #define VS1053_DREQ     7     // VS1053 Data request, ideally an Interrupt pin
 
+// Feather ESP32-S2 and ESP32-S3 (all variants)
+#elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)        || \
+      defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2_REVTFT) || \
+      defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2_TFT)    || \
+      defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3)        || \
+      defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3_NOPSRAM)|| \
+      defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3_REVTFT) || \
+      defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3_TFT)
+  #define VS1053_CS       6     // VS1053 chip select pin (output)
+  #define VS1053_DCS     10     // VS1053 Data/command select pin (output)
+  #define CARDCS          5     // Card chip select pin
+  #define VS1053_DREQ     9     // VS1053 Data request, ideally an Interrupt pin
+
 // Feather ESP32
 #elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
   #define VS1053_CS      32     // VS1053 chip select pin (output)


### PR DESCRIPTION
This PR adds ESP32-S2 / ESP-S3 Feather pin definitions so the examples/feather_player works on more Feather variants. These are defined the more general ESP32 definition otherwise it picks up pins for a Huzzah board.

Based on [forum thread](https://forums.adafruit.com/viewtopic.php?p=1074442).

Tested on.

```
+------------------------+---------------------------+
| Item                   | Value                     |
+------------------------+---------------------------+
| Arduino IDE            | 2.3.6                     |
| Controller             | Feather ESP32-S3 2MB PSRAM|
| Music Maker            | FeatherWing               |
| ESP BSP                | 3.3.3                     |
| Adafruit VS1053 lib    | 1.3.2                     |
+------------------------+---------------------------+
```

