### PR TITLE
Bump to 1.4.5 Arduino Library Manager not updating

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This is a library for the Adafruit VS1053 Codec Breakout and Music Mak
 category=Device Control
 url=https://github.com/adafruit/Adafruit_VS1053_Library
 architectures=*
-depends=Adafruit BusIO, SdFat - Adafruit Fork
+depends=Adafruit BusIO, SD

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit VS1053 Library
-version=1.4.4
+version=1.4.5
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=This is a library for the Adafruit VS1053 Codec Breakout and Music Maker Shields
@@ -7,4 +7,4 @@ paragraph=This is a library for the Adafruit VS1053 Codec Breakout and Music Mak
 category=Device Control
 url=https://github.com/adafruit/Adafruit_VS1053_Library
 architectures=*
-depends=SD, Adafruit BusIO
+depends=Adafruit BusIO

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This is a library for the Adafruit VS1053 Codec Breakout and Music Mak
 category=Device Control
 url=https://github.com/adafruit/Adafruit_VS1053_Library
 architectures=*
-depends=Adafruit BusIO
+depends=Adafruit BusIO, SdFat - Adafruit Fork


### PR DESCRIPTION
Fix Arduino Library Manager indexing which stopped updating after the Aug 2023 release version 1.3.2 of this library.

Bumping to v1.4.5 and modifying a dependency ilbrary:

SD --> SdFat - Adafruit Fork

<img width="344" height="689" alt="Screenshot 2026-02-17 at 8 35 52 AM" src="https://github.com/user-attachments/assets/4c506609-1aed-4460-93d0-51e494eeec61" />


[forum issue](https://forums.adafruit.com/viewtopic.php?p=1082059#p1082059)